### PR TITLE
fix: export enums previously erased during compilation

### DIFF
--- a/src/configure/ctx.ts
+++ b/src/configure/ctx.ts
@@ -27,7 +27,7 @@ export interface Variable {
   type?: VariableType;
 }
 
-export const enum VariableType {
+export enum VariableType {
   String = "string",
   Number = "number",
   Array = "array",

--- a/src/project/assets/asset-types.ts
+++ b/src/project/assets/asset-types.ts
@@ -26,7 +26,7 @@ export interface Assets {
   pwaSplashDark?: InputAsset | null;
 }
 
-export const enum AssetKind {
+export enum AssetKind {
   Logo = 'logo',
   LogoDark = 'logo-dark',
   AdaptiveIcon = 'adaptive-icon',
@@ -36,13 +36,13 @@ export const enum AssetKind {
   NotificationIcon = 'notification-icon'
 }
 
-export const enum Platform {
+export enum Platform {
   Any = 'any',
   Ios = 'ios',
   Android = 'android'
 }
 
-export const enum Format {
+export enum Format {
   Png = 'png',
   Jpeg = 'jpeg',
   Svg = 'svg',
@@ -50,19 +50,19 @@ export const enum Format {
   Unknown = 'unknown',
 }
 
-export const enum Orientation {
+export enum Orientation {
   Default = '',
   Portrait = 'portrait',
   Landscape = 'landscape',
 }
 
-export const enum Theme {
+export enum Theme {
   Any = 'any',
   Light = 'light',
   Dark = 'dark',
 }
 
-export const enum AndroidDensity {
+export enum AndroidDensity {
   Default = '',
   Ldpi = 'ldpi',
   Mdpi = 'mdpi',
@@ -118,7 +118,7 @@ export interface IosOutputAssetTemplate extends OutputAssetTemplate {
 }
 
 // https://developer.apple.com/library/archive/documentation/Xcode/Reference/xcode_ref-Asset_Catalog_Format/ImageSetType.html#//apple_ref/doc/uid/TP40015170-CH25-SW2
-export const enum IosIdiom {
+export enum IosIdiom {
   Universal = 'universal',
   iPhone = 'iphone',
   iPad = 'ipad',

--- a/src/project/definitions.ts
+++ b/src/project/definitions.ts
@@ -54,7 +54,7 @@ export type IosProjectName = string;
 
 export type AndroidResDir = 'anim' | 'animator' | 'color' | 'drawable' | 'font' | 'interpolator' | 'layout' | 'menu' | 'mipmap' | 'navigation' | 'raw' | 'transition' | 'values' | 'xml' | string;
 
-export const enum AndroidGradleInjectType {
+export enum AndroidGradleInjectType {
   Infer = 'infer',
   Method = 'method',
   Variable = 'variable'


### PR DESCRIPTION
This PR changes how some enumerations are exported, replacing the `const enum` marking with the standard `enum`. Enumerations marked `const enum` will be erased during compilation, preventing consumers from accessing enumeration values in their code. 

As an example, the following line of code currently fails to run:

```
const asset = new InputAsset(pathToAsset, AssetKind.Logo, Platform.Any)
// SyntaxError: The requested module '@capacitor/trampoline' does not provide an export named 'AssetKind'
//    at ModuleJob._instantiate (node:internal/modules/esm/module_job:134:21)
//    at async ModuleJob.run (node:internal/modules/esm/module_job:217:5)
//    at async ModuleLoader.import (node:internal/modules/esm/loader:316:24)
//    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:123:5)
```

This is due to `AssetKind` being tree-shaken out during compilation. However, it remains as part of the typing definitions, which creates a confusing experience where IDEs will pick up the enumeration, but when the code is transpiled, it will break.  